### PR TITLE
Fixed a typo and moved the hardcoded url to constants file

### DIFF
--- a/server/src/common/swagger/constants.ts
+++ b/server/src/common/swagger/constants.ts
@@ -2,3 +2,4 @@ export const SWAGGER_API_ROOT = 'api/docs';
 export const SWAGGER_API_NAME = 'Nest Next Boilerplate v1 API';
 export const SWAGGER_API_DESCRIPTION = 'Basic docs for API in version 1';
 export const SWAGGER_API_CURRENT_VERSION = '1.0';
+export const SERVER_URL = 'http://localhost:4000';

--- a/server/src/common/swagger/index.ts
+++ b/server/src/common/swagger/index.ts
@@ -5,11 +5,12 @@ import {
   SWAGGER_API_NAME,
   SWAGGER_API_DESCRIPTION,
   SWAGGER_API_CURRENT_VERSION,
+  SERVER_URL
 } from './constants'
 
 export const setupSwagger = (app: INestApplication) => {
-	const server = 'http://localhost:4000/api'
-	const docs = 'http://localhost:4000/api/docs'
+	const server = `${SERVER_URL}/api`
+	const docs = `${SERVER_URL}/api/docs`
 
     const options = new DocumentBuilder()
         .setTitle(SWAGGER_API_NAME)
@@ -23,5 +24,5 @@ export const setupSwagger = (app: INestApplication) => {
     SwaggerModule.setup(SWAGGER_API_ROOT, app, document)
 
     const logger = new Logger('Documentation')
-	logger.log(`API Documentation for "${server}" is avaible at "${docs}"`)
+	logger.log(`API Documentation for "${server}" is available at "${docs}"`)
 }


### PR DESCRIPTION
There is a typo in the swagger doc log; moved the hardcoded server url to constants file.